### PR TITLE
remove invalid no of modules from program page

### DIFF
--- a/lms/templates/programs/programs.html
+++ b/lms/templates/programs/programs.html
@@ -43,12 +43,7 @@
                         <div class="col-sm-6 card-key"><i class="fa fa-tachometer"></i><span>Effort:</span></div>
                         <div class="col-sm-6 card-value">${program["effort"]}</div>
                     </div>
-                    
-                    <div class="row">
-                        <div class="col-sm-6 card-key"><i class="fa fa-book"></i><span>No of modules:</span></div>
-                        <div class="col-sm-6 card-value">${program["number_of_modules"]}</div>
-                    </div>
-                    
+
                     <div class="row">
                         <div class="col-sm-6 card-key"><i class="fa fa-graduation-cap"></i><span>Subject:</span></div>
                         <div class="col-sm-6 card-value">Software Development</div>


### PR DESCRIPTION
Remove redundant 'No of modules' from program page. It currently shows 25 modules, which is invalid and confuses students. 