### PR TITLE
Unenrollment automation

### DIFF
--- a/lms/djangoapps/student_enrollment/management/commands/enrollment.py
+++ b/lms/djangoapps/student_enrollment/management/commands/enrollment.py
@@ -7,7 +7,7 @@ from student_enrollment.utils import (
     get_or_register_student, post_to_zapier
 )
 from student_enrollment.zoho import (
-    get_students,
+    get_students_to_be_enrolled,
     parse_course_of_interest_code
 )
 from lms.djangoapps.student_enrollment.models import EnrollmentStatusHistory
@@ -16,8 +16,8 @@ from lms.djangoapps.student_enrollment.models import ProgramAccessStatus
 """
 Students starting the Full Stack Developer course should initially not be
 enrolled into the Careers module. It should be made available after the submission
-of the Interactive Frontend Development. See "Enroll student in careers module" 
-Zap. 
+of the Interactive Frontend Development. See "Enroll student in careers module"
+Zap.
 
 This collection is used to store any courses that should be excluded from the
 initial student onboarding/enrollment process like the Careers module.
@@ -32,25 +32,25 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         pass
-    
+
     def handle(self, *args, **options):
         """
         The main handler for the program enrollment management command.
         This will retrieve all of the users from the Zoho CRM API and
         will enroll all of the students that have a status of
         `Enrolling`.
-        
+
         If a student doesn't exist in the system then a new a account
         will be registered. A student can be unenrolled from courses
         if they miss payments (or other circumstances) which means they
         may already be registered in the system.
         """
 
-        zoho_students = get_students()
+        zoho_students = get_students_to_be_enrolled()
 
         for student in zoho_students:
             if not student['Email']:
-                continue 
+                continue
 
             # Get the user, the user's password, and their enrollment type
             user, password, enrollment_type = get_or_register_student(
@@ -59,7 +59,7 @@ class Command(BaseCommand):
             # Get the code for the course the student is enrolling in
             program_to_enroll_in = parse_course_of_interest_code(
                 student['Course_of_Interest_Code'])
-            
+
             # Get the Program that contains the th Zoho program code
             program = Program.objects.get(program_code=program_to_enroll_in)
 
@@ -81,10 +81,10 @@ class Command(BaseCommand):
             if not created:
                 access.allowed_access = True
                 access.save()
-            
+
             post_to_zapier(settings.ZAPIER_ENROLLMENT_URL, {"email": user.email})
 
-            enrollment_status = EnrollmentStatusHistory(student=user, program=program, 
+            enrollment_status = EnrollmentStatusHistory(student=user, program=program,
                                                         registered=bool(user),
                                                         enrollment_type=enrollment_type,
                                                         enrolled=bool(program_enrollment_status),

--- a/lms/djangoapps/student_enrollment/management/commands/enrollment.py
+++ b/lms/djangoapps/student_enrollment/management/commands/enrollment.py
@@ -7,7 +7,7 @@ from student_enrollment.utils import (
     get_or_register_student, post_to_zapier
 )
 from student_enrollment.zoho import (
-    get_students_to_be_enrolled,
+    get_students,
     parse_course_of_interest_code
 )
 from lms.djangoapps.student_enrollment.models import EnrollmentStatusHistory
@@ -46,7 +46,7 @@ class Command(BaseCommand):
         may already be registered in the system.
         """
 
-        zoho_students = get_students_to_be_enrolled()
+        zoho_students = get_students('Enroll')
 
         for student in zoho_students:
             if not student['Email']:

--- a/lms/djangoapps/student_enrollment/management/commands/enrollment.py
+++ b/lms/djangoapps/student_enrollment/management/commands/enrollment.py
@@ -46,7 +46,7 @@ class Command(BaseCommand):
         may already be registered in the system.
         """
 
-        zoho_students = get_students('Enroll')
+        zoho_students = get_students(lead_status='Enroll')
 
         for student in zoho_students:
             if not student['Email']:

--- a/lms/djangoapps/student_enrollment/management/commands/unenrollment.py
+++ b/lms/djangoapps/student_enrollment/management/commands/unenrollment.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from ci_program.models import Program
 from student_enrollment.utils import get_or_register_student
 from student_enrollment.zoho import (
-    get_students_to_be_unenrolled,
+    get_students,
     parse_course_of_interest_code,
     update_student_record
 )
@@ -30,7 +30,7 @@ class Command(BaseCommand):
         # we'll set the type as a constact
         ENROLLMENT_TYPE = 1
 
-        zoho_students = get_students_to_be_unenrolled()
+        zoho_students = get_students('Unenroll')
 
         for student in zoho_students:
             # Get the user

--- a/lms/djangoapps/student_enrollment/management/commands/unenrollment.py
+++ b/lms/djangoapps/student_enrollment/management/commands/unenrollment.py
@@ -1,6 +1,3 @@
-"""
-NOTE: WIP NOT TESTED!!!
-"""
 from django.core.management.base import BaseCommand, CommandError
 from django.core.exceptions import ObjectDoesNotExist
 from django.contrib.auth.models import User
@@ -13,7 +10,7 @@ from student_enrollment.zoho import (
     update_student_record
 )
 from lms.djangoapps.student_enrollment.models import EnrollmentStatusHistory
-
+from lms.djangoapps.student_enrollment.models import ProgramAccessStatus
 
 class Command(BaseCommand):
     help = 'Unenroll students from their relevant programs'

--- a/lms/djangoapps/student_enrollment/management/commands/unenrollment.py
+++ b/lms/djangoapps/student_enrollment/management/commands/unenrollment.py
@@ -30,7 +30,7 @@ class Command(BaseCommand):
         # we'll set the type as a constact
         ENROLLMENT_TYPE = 1
 
-        zoho_students = get_students('Unenroll')
+        zoho_students = get_students(lead_status='Unenroll')
 
         for student in zoho_students:
             # Get the user

--- a/lms/djangoapps/student_enrollment/management/commands/unenrollment.py
+++ b/lms/djangoapps/student_enrollment/management/commands/unenrollment.py
@@ -66,7 +66,7 @@ class Command(BaseCommand):
 
             # Send the email
             email_sent_status = program.send_email(
-                user, program.name, ENROLLMENT_TYPE)
+                user, ENROLLMENT_TYPE, None)
 
             # Set the students access level (i.e. determine whether or not a student
             # is allowed to access to the LMS.

--- a/lms/djangoapps/student_enrollment/zoho.py
+++ b/lms/djangoapps/student_enrollment/zoho.py
@@ -9,26 +9,19 @@ REFRESH_TOKEN = settings.ZOHO_REFRESH_TOKEN
 REFRESH_ENDPOINT = settings.ZOHO_REFRESH_ENDPOINT
 COQL_ENDPOINT = settings.ZOHO_COQL_ENDPOINT
 
-STUDENTS_TO_BE_ENROLLED_QUERY = """
+QUERY = """
 SELECT Email, Full_Name, Course_of_Interest_Code
 FROM Contacts
-WHERE Lead_Status = 'Enroll'
-AND Course_of_Interest_Code is not null
-LIMIT {page},{per_page}
-"""
-STUDENTS_TO_BE_UNENROLLED_QUERY = """
-SELECT Email, Full_Name, Course_of_Interest_Code
-FROM Contacts
-WHERE Lead_Status = 'Unenroll'
+WHERE Lead_Status = {lead_status}
 AND Course_of_Interest_Code is not null
 LIMIT {page},{per_page}
 """
 RECORDS_PER_PAGE = 200
 
 
-def get_students_to_be_enrolled():
+def get_students(lead_status):
     """Fetch from Zoho all students
-    with status of 'Enroll'
+    with the provided lead_status
     API documentation for this endpoint:
     https://www.zohoapis.com/crm/v2/coql
     """
@@ -36,32 +29,14 @@ def get_students_to_be_enrolled():
     auth_headers = get_auth_headers()
 
     for page in count():
-        query = STUDENTS_TO_BE_ENROLLED_QUERY.format(
+        query = QUERY.format(
+                    lead_status=lead_status,
                     page=page*RECORDS_PER_PAGE,
                     per_page=RECORDS_PER_PAGE)
         students_resp = requests.post(
             COQL_ENDPOINT,
             headers=auth_headers,
             json={"select_query":query})
-        if students_resp.status_code != 200:
-            return students
-
-        students.extend(students_resp.json()['data'])
-        if not students_resp.json()['info']['more_records']:
-            return students
-
-def get_students_to_be_unenrolled():
-    students = []
-    auth_headers = get_auth_headers()
-
-    for page in count():
-        query = STUDENTS_TO_BE_UNENROLLED_QUERY.format(
-                    page=page*RECORDS_PER_PAGE,
-                    per_page=RECORDS_PER_PAGE)
-        students_resp = requests.post(
-                COQL_ENDPOINT,
-                headers=auth_headers,
-                json={"select_query":query})
         if students_resp.status_code != 200:
             return students
 


### PR DESCRIPTION
**Description:** 
Fixed the unenrollment.py script, that searches for students with a CRM lead status of 'Unenroll', unenrolls them from the Full Stack course, sends an email notification to the student and triggers a zap to update the student's CRM lead status to 'Unenrolled'

**ClickUp task:**
[Fully automate student unenrollment](https://app.clickup.com/t/4jjq1q)

**Configuration instructions:**
UNENROLLMENT_ZAPIER_ENDPOINT to be updated in lms.env.json

**Manual testing:**
Manually tested the end-to-end process with the ci dummy user on the following dev instance: 
[nakita-dev-lms-20200602](https://eu-west-1.console.aws.amazon.com/ec2/v2/home?region=eu-west-1#Instances:search=nakita-dev-lms-20200602;sort=instanceState)

**Concerns/Need to knows:** 
Created a follow up ticket relating to unenrollment process:
[Ask SC /Jane to agree if we should provide extended access to Careers module beyond sub end date](https://app.clickup.com/t/5prb9f)
If we agree to provide extended access, we'll need to go back and exclude the Careers module from the unenrollment process. 

Commits from the code-institute-team user are the functional changes I made to the script on the dev instance using vim (git config on dev instance is set up to use the code-insititute-team user). All other commits relate to refactoring. All changes were tested on the dev instance. 
