### PR TITLE
LMS no longer sends unenrollment email, this will be handled by CRM i…

### DIFF
--- a/lms/djangoapps/student_enrollment/management/commands/unenrollment.py
+++ b/lms/djangoapps/student_enrollment/management/commands/unenrollment.py
@@ -61,10 +61,6 @@ class Command(BaseCommand):
             # Unenroll the student from the program
             program_enrollment_status = program.unenroll_student_from_program(user)
 
-            # Skip sending the email from the LMS
-            # Student Care team would prefer to use the CRM instead
-            email_sent_status = False
-
             # Set the students access level (i.e. determine whether or not a student
             # is allowed to access to the LMS.
             access, created = ProgramAccessStatus.objects.get_or_create(
@@ -79,9 +75,11 @@ class Command(BaseCommand):
             # Create a new entry in the EnrollmentStatusHistory to
             # indicate whether or not each step of the process was
             # successful
+            # email_sent is set to False, no requirement to send email from LMS
+            # Automated unenrollment emails are configured in Zoho CRM
             enrollment_status = EnrollmentStatusHistory(student=user, program=program,
                                                         registered=bool(user),
                                                         enrollment_type=ENROLLMENT_TYPE,
                                                         enrolled=bool(program_enrollment_status),
-                                                        email_sent=email_sent_status)
+                                                        email_sent=False)
             enrollment_status.save()

--- a/lms/djangoapps/student_enrollment/management/commands/unenrollment.py
+++ b/lms/djangoapps/student_enrollment/management/commands/unenrollment.py
@@ -61,9 +61,9 @@ class Command(BaseCommand):
             # Unenroll the student from the program
             program_enrollment_status = program.unenroll_student_from_program(user)
 
-            # Send the email
-            email_sent_status = program.send_email(
-                user, ENROLLMENT_TYPE, None)
+            # Skip sending the email from the LMS
+            # Student Care team would prefer to use the CRM instead
+            email_sent_status = False
 
             # Set the students access level (i.e. determine whether or not a student
             # is allowed to access to the LMS.


### PR DESCRIPTION
**Description:** 
Following feedback in sprint demo, Student Care have opted to send unenrollment emails from the CRM so I've removed the trigger to send an unenrollment email from the LMS. 

**ClickUp task:**
[Remove action to send email following unenrollment from LMS, to be sent from CRM instead](https://app.clickup.com/t/5upcvb)

**Merge deadline:** List merge deadline (if any)
Wednesday 10 June 2020 at 9.30am

Manual testing:
Manually tested the end-to-end process with the ci dummy user on the following dev instance:
nakita-dev-lms-20200602
