### PR TITLE
Bugfix -  Renaming Old Django module to fix RDS export

### DIFF
--- a/lms/djangoapps/learning_success/management/commands/export_all_activity_records.py
+++ b/lms/djangoapps/learning_success/management/commands/export_all_activity_records.py
@@ -81,7 +81,7 @@ def days_into_data(first_active, completion_timestamps):
 
 def format_module_field(module_name, suffix):
     # TODO: Rename module name once there is no student who can view it
-    if module_name == 'Full Stack Frameworks with Django - retiring July 31':
+    if module_name == 'Full Stack Frameworks with Django - retiring Aug 31':
         return 'full_stack_frameworks_with_django'
     return module_name.lower().replace(' ', '_') + suffix
 

--- a/lms/djangoapps/learning_success/management/commands/export_all_activity_records.py
+++ b/lms/djangoapps/learning_success/management/commands/export_all_activity_records.py
@@ -80,6 +80,7 @@ def days_into_data(first_active, completion_timestamps):
 
 
 def format_module_field(module_name, suffix):
+    # TODO: Rename module name once there is no student who can view it
     if module_name == 'Full Stack Frameworks with Django - retiring July 31':
         return 'full_stack_frameworks_with_django'
     return module_name.lower().replace(' ', '_') + suffix

--- a/lms/djangoapps/learning_success/management/commands/export_all_activity_records.py
+++ b/lms/djangoapps/learning_success/management/commands/export_all_activity_records.py
@@ -80,6 +80,8 @@ def days_into_data(first_active, completion_timestamps):
 
 
 def format_module_field(module_name, suffix):
+    if module_name == 'Full Stack Frameworks with Django - retiring July 31':
+        return 'full_stack_frameworks_with_django'
     return module_name.lower().replace(' ', '_') + suffix
 
 


### PR DESCRIPTION
**Description:**
Some progress for students currently still enrolled in the old Django module is not counted towards the progress in the Django module in the LMS sheet.

**ClickUp task:**
[Rename old Django module](https://app.clickup.com/t/60j8dv)

**Manual Testing:**
Ran the export from the dev server which worked fine and re-created the lms_activity table in the RDS.