### PR TITLE
Removing max-width from base scss file

### DIFF
--- a/lms/static/sass/base/_layouts.scss
+++ b/lms/static/sass/base/_layouts.scss
@@ -65,7 +65,6 @@ body.view-in-course {
   .wiki-wrapper,
   .teams-wrapper,
   .static_tab_wrapper {
-    max-width: 1180px;
     margin: 0 auto;
     padding: 0;
   }


### PR DESCRIPTION
**Description:** Width of courses column was too restrictive (at 1080px), remove restriction.

**Youtrack:** ClickUp task id: #6arvuf

**Merge deadline:** List merge deadline (if any)

**Configuration instructions:** N/A

**Testing instructions:**

1. Login as Student
2. Begin a Course
3. Verify width of column reaches sides of screen
4. Verify for other student facing views

**Reviewers:**
- [ stefan] tag reviewer
- [ nakita] tag reviewer

**Related Confluence documents:**
N/A

**Merge checklist:**
- [x] All reviewers approved
- [ ] CI build is green
- [ ] Documentation in source code updated
- [ ] All related Confluence documentation is updated (including deployment documentation)
- [ ] Commits are squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** Having failed to override this setting in the ci-theme, it was agreed to make the change to edx proper, given that an upgrade is on the way.
