### PR TITLE
Fix broken LMS RDS export script

### DIFF
--- a/lms/djangoapps/learning_success/management/commands/export_all_activity_records.py
+++ b/lms/djangoapps/learning_success/management/commands/export_all_activity_records.py
@@ -315,12 +315,12 @@ class Command(BaseCommand):
 
         df = pd.DataFrame(student_data)
         engine = create_engine(CONNECTION_STRING, echo=False)
-        write_type = 'replace'
-        interval = 1000
-        # df.shape[0] holds the number of rows in the DataFrame
-        for subset in range(int(math.ceil(df.shape[0]/interval))):
-            df_subset = df.loc[subset*interval:subset*interval+(interval-1)]
+        rows_per_packet = 1000
+        row_count = df.shape[0]
+
+        for subset_start in range(0, row_count, rows_per_packet):
+            write_type = 'replace' if subset_start == 0 else 'append'
+            df_subset = df.loc[subset_start:subset_start+rows_per_packet-1]
             df_subset.to_sql(name=LMS_ACTIVITY_TABLE,
                     con=engine, 
                     if_exists=write_type)
-            write_type='append'

--- a/lms/djangoapps/learning_success/management/commands/export_all_activity_records.py
+++ b/lms/djangoapps/learning_success/management/commands/export_all_activity_records.py
@@ -318,10 +318,9 @@ class Command(BaseCommand):
         write_type = 'replace'
         interval = 1000
         # df.shape[0] holds the number of rows in the DataFrame
-        for i in range(math.ceil(df.shape[0]/interval)): 
-            print(f"From {i*interval} to {i*interval+(interval-1)}")
-            print(df.loc[i*interval:i*interval+(interval-1)])
-            df.to_sql(name=LMS_ACTIVITY_TABLE, 
+        for subset in range(int(math.ceil(df.shape[0]/interval))):
+            df_subset = df.loc[subset*interval:subset*interval+(interval-1)]
+            df_subset.to_sql(name=LMS_ACTIVITY_TABLE,
                     con=engine, 
-                    if_exists='replace')
+                    if_exists=write_type)
             write_type='append'

--- a/lms/djangoapps/learning_success/management/commands/export_all_activity_records.py
+++ b/lms/djangoapps/learning_success/management/commands/export_all_activity_records.py
@@ -33,6 +33,7 @@ CONNECTION_STRING = 'mysql+mysqldb://%s:%s@%s:%s/%s%s' % (
     '?charset=utf8')
 
 LMS_ACTIVITY_TABLE = 'lms_activity'
+ROWS_PER_PACKET = 1000
 
 
 def harvest_course_tree(tree, output_dict, prefix=()):
@@ -315,12 +316,11 @@ class Command(BaseCommand):
 
         df = pd.DataFrame(student_data)
         engine = create_engine(CONNECTION_STRING, echo=False)
-        rows_per_packet = 1000
         row_count = df.shape[0]
 
-        for subset_start in range(0, row_count, rows_per_packet):
+        for subset_start in range(0, row_count, ROWS_PER_PACKET):
             write_type = 'replace' if subset_start == 0 else 'append'
-            df_subset = df.loc[subset_start:subset_start+rows_per_packet-1]
+            df_subset = df.loc[subset_start:subset_start+ROWS_PER_PACKET-1]
             df_subset.to_sql(name=LMS_ACTIVITY_TABLE,
                     con=engine, 
                     if_exists=write_type)

--- a/lms/djangoapps/learning_success/management/commands/export_all_activity_records.py
+++ b/lms/djangoapps/learning_success/management/commands/export_all_activity_records.py
@@ -9,7 +9,7 @@ from lms.djangoapps.learning_success.management.commands.challenges_helper impor
 from collections import Counter, defaultdict, OrderedDict
 from datetime import datetime, timedelta
 import json
-
+import math
 import pandas as pd
 import pytz
 import requests
@@ -315,6 +315,13 @@ class Command(BaseCommand):
 
         df = pd.DataFrame(student_data)
         engine = create_engine(CONNECTION_STRING, echo=False)
-        df.to_sql(name=LMS_ACTIVITY_TABLE, 
-                  con=engine, 
-                  if_exists='replace')
+        write_type = 'replace'
+        interval = 1000
+        # df.shape[0] holds the number of rows in the DataFrame
+        for i in range(math.ceil(df.shape[0]/interval)): 
+            print(f"From {i*interval} to {i*interval+(interval-1)}")
+            print(df.loc[i*interval:i*interval+(interval-1)])
+            df.to_sql(name=LMS_ACTIVITY_TABLE, 
+                    con=engine, 
+                    if_exists='replace')
+            write_type='append'


### PR DESCRIPTION
**Description:**
The LMS extract to the RDS is currently failing because the amount of data sent to the RDS in one go is too much for the connection to handle and times out. We are getting an exceeds 'max_allowed_packets' error in the RDS error log. I encountered this before when testing writing more rows and the only way to change that is to split exporting the data to the RDS into smaller subsets with a loop.

**Clickup:**
[Fix failing lms export to RDS](https://app.clickup.com/t/6gteb6)

**Manual Testing:**
1) Ran the extract with a small set of 50 students which succeeded. 
2) Ran the extract with all students which succeeded as well.
