### PR TITLE
Suffix fix for old Django module 

### DIFF
--- a/lms/djangoapps/learning_success/management/commands/export_all_activity_records.py
+++ b/lms/djangoapps/learning_success/management/commands/export_all_activity_records.py
@@ -83,7 +83,7 @@ def days_into_data(first_active, completion_timestamps):
 def format_module_field(module_name, suffix):
     # TODO: Rename module name once there is no student who can view it
     if module_name == 'Full Stack Frameworks with Django - retiring Aug 31':
-        return 'full_stack_frameworks_with_django'
+        return 'full_stack_frameworks_with_django' + suffix
     return module_name.lower().replace(' ', '_') + suffix
 
 


### PR DESCRIPTION
**Description:** 
Adding missing suffix to the temporary fix for the old Django module in order to attribute the fraction to the correct key in the student data dictionary for the Django fractions showing up on the LMS extract.

**Clickup Task:**
[Investigate Velocity drop](https://app.clickup.com/t/6epq4f)

**Manual Testing:**
Tested code in IPython on a dev instance using a student who is missing the fractions in 'full_stack_frameworks_with_django_fraction_before_14d' and 'full_stack_frameworks_with_django_fraction_within_14d' keys.