### PR TITLE
Change Springboard registration email so the sender is springboard@ rather than ciara.browne@

### DIFF
--- a/lms/djangoapps/ci_program/models.py
+++ b/lms/djangoapps/ci_program/models.py
@@ -243,10 +243,12 @@ class Program(TimeStampedModel):
         """
 
         # Set the values that will be used for sending the email
+        student_password = password
         to_address = student.email
         from_address = 'learning@codeinstitute.net'
-        student_password = password
-        
+        if "Springboard" in self.name:
+            from_address = 'springboard@codeinstitute.net' 
+
         self.enrollment_type = enrollment_type
         
         if self.name == "Five Day Coding Challenge":
@@ -254,6 +256,7 @@ class Program(TimeStampedModel):
                 self.course_codes.first().key)
         else:
             module_url = None
+
         
         # Get the email location & subject
         template_location, subject = self.email_template_location

--- a/lms/djangoapps/ci_program/models.py
+++ b/lms/djangoapps/ci_program/models.py
@@ -246,7 +246,7 @@ class Program(TimeStampedModel):
         student_password = password
         to_address = student.email
         from_address = 'learning@codeinstitute.net'
-        if self.name == "All Access Coding Challenges - In Partnership With Springboard":
+        if self.program_code == 'SBAACC':
             from_address = 'springboard@codeinstitute.net' 
 
         self.enrollment_type = enrollment_type

--- a/lms/djangoapps/ci_program/models.py
+++ b/lms/djangoapps/ci_program/models.py
@@ -246,7 +246,7 @@ class Program(TimeStampedModel):
         student_password = password
         to_address = student.email
         from_address = 'learning@codeinstitute.net'
-        if "Springboard" in self.name:
+        if self.name == "All Access Coding Challenges - In Partnership With Springboard":
             from_address = 'springboard@codeinstitute.net' 
 
         self.enrollment_type = enrollment_type


### PR DESCRIPTION
**Description:** 
Following a request from Channel team, updating the sender of the Springboard registration email so the sender is springboard@codeinstitute.net rather than ciara.browne@codeinstitute.net. Changes to the contents of the email can be found in a related PR, [Change email references from ciara.browne@ to springboard@](https://github.com/Code-Institute-Org/ci-theme/pull/40) the [ci-theme repo](https://github.com/Code-Institute-Org/ci-theme)

**ClickUp task:** 
[Replace learning@ with springboard@ as sender of SB registration email](https://app.clickup.com/t/6yp49q)

**Merge deadline:**
Wed 5th Aug @ 9am

**Configuration instructions:** 
None

**Testing instructions:**
Manually tested with ci dummy user on the following dev instance:
[nakita-dev-lms-20200724](http://99.81.72.255)

Received the following email to cidummystudent@gmail.com, which has the expected sender of springboard@
![image](https://user-images.githubusercontent.com/24976693/88791502-bd066f00-d191-11ea-8bd2-4a6b20a2a7b0.png)

**Reviewers:**
- [ ] gomyar

**Merge checklist:**
- [ ] All reviewers approved
- [ ] Commits are squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** 
This change affects all students enrolled into the following course:
course-v1:CodeInstitute+5DCC+SBAACC
A second SB course - course-v1:CodeInstitute+5DCC+SpringboardAACC - was queried as part of this task but is no longer in use so was not included.
